### PR TITLE
fix: minor changes regarding EnKoe

### DIFF
--- a/server/data/players/index.ts
+++ b/server/data/players/index.ts
@@ -171,6 +171,7 @@ const playerNicknameMapRaw: Record<string, string> = {
   "AFKay": "唐傀",
   "CJRzzZ": "自古二楼",
   "Lp|葉山": "葉山",
+  "KDF EnKoe": "EnKoe",
 
   "甜甜花酿鸡队": "",
   "莲花酥队": "",

--- a/server/data/tournaments/4.8/外服赛事-小王子杯-太平洋赛区-淘汰赛.ts
+++ b/server/data/tournaments/4.8/外服赛事-小王子杯-太平洋赛区-淘汰赛.ts
@@ -211,7 +211,7 @@ export default defineTournament({
               ],
             },
             {
-              playerA: "KDF EnKoo",
+              playerA: "KDF EnKoe",
               playerB: "Dio",
               video: "https://www.bilibili.com/video/BV1rw4m1r7ff",
               banned: [
@@ -1197,7 +1197,7 @@ export default defineTournament({
               ],
             },
             {
-              playerA: "KDF Enkoe",
+              playerA: "KDF EnKoe",
               playerB: "Chikuwa",
               video: "https://www.youtube.com/watch?v=_0-jypYMArw",
               banned: [


### PR DESCRIPTION
Some minor fixes to player names on PC Pacific, all of which target EnKoe (for some reason, his name was the only one that had problems).

As for the alias edit: as the system does not support team tags right now, I'm just adding it in advance. (Just in case EnKoe leaves KDF after this tournament - it's esports anyway, things like that are bound to happen.)